### PR TITLE
Make bin/*lld* available to bazel

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -34,10 +34,9 @@ filegroup(
 
 filegroup(
     name = "ld",
-    srcs = [
-        "bin/ld.lld",
-        "bin/lld-link",
-    ],
+    srcs = glob([
+        "bin/*lld*",
+    ]),
 )
 
 filegroup(


### PR DESCRIPTION
Bazel 7 seems to be more strict about this. Before this was only referencing the symlinks and was not making the files pointed at available